### PR TITLE
Add Express server setup with Apollo Server and static asset serving

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,9 +11,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "apollo-server-express": "^3.12.0",
     "bcrypt": "^5.1.0",
     "cloudinary": "^1.37.1",
     "dotenv": "^16.3.0",
+    "express": "^4.18.2",
     "mongoose": "^7.3.0",
     "validator": "^13.9.0"
   }

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,44 @@
+const express = require("express"); // Import the Express framework
+const { ApolloServer } = require("apollo-server-express"); // Import Apollo Server
+const path = require("path");
+const db = require("./config/connection"); // Import the database connection
+require("dotenv").config(); // Load environment variables from .env file
+
+const app = express(); // Create an instance of the Express application
+const PORT = process.env.PORT || 3001; // Set the port to either the environment variable or 3001 as a default
+
+// Create a new ApolloServer instance, providing the type definitions and resolvers
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+app.use(express.urlencoded({ extended: false })); // Middleware to parse URL-encoded request bodies
+app.use(express.json()); // Middleware to parse JSON request bodies
+
+// Serve static assets from "client/build" in production mode
+if (process.env.NODE_ENV === "production") {
+  app.use(express.static(path.join(__dirname, "../client/build"))); 
+}
+
+// Serve the index.html file for all other routes
+app.get("*", (req, res) => {
+  res.sendFile(path.join(__dirname, "../client/build/index.html")); 
+});
+
+const startApolloServer = async () => {
+  await server.start(); // Start the Apollo Server
+  server.applyMiddleware({ app }); // Apply the Apollo Server middleware to the Express app
+
+  // Open the database connection and start the server
+  db.once("open", () => {
+    app.listen(PORT, () => {
+      console.log(`API server running on port ${PORT}!`);
+      console.log(
+        `Use GraphQL at http://localhost:${PORT}${server.graphqlPath}`
+      ); // Log the GraphQL endpoint URL
+    });
+  });
+};
+
+startApolloServer();


### PR DESCRIPTION
- Created an instance of the Express application
- Add middleware to the instance of the express application that parse URL-encoded & JSON requests
- Create a new Apollo Server instance, providing the type definitions and resolvers
- Define an async function to start the Apollo Server and apply the express middleware, and open the database connection