### PR TITLE
Updated handleCardPayment function to ensure successful order and payment creation before proceeding

### DIFF
--- a/client/src/components/Navbar/index.js
+++ b/client/src/components/Navbar/index.js
@@ -214,7 +214,7 @@ const Navbar = () => {
           >
             {/* User icon and User dropdown menu */}
             {/* If the user is logged in then display the user menu options */}
-            {isLoggedIn ? (
+            {AuthService.loggedIn() ? (
               <Dropdown overlay={userMenu} trigger={["hover"]}>
                 <UserOutlined
                   style={{
@@ -242,7 +242,7 @@ const Navbar = () => {
                 // Only allow the dropdown for larger screens as it covers a large portion of the screen for smaller devices which could distract users
                 windowSize >= 768 ? (
                   <>
-                    {isLoggedIn ? (
+                    {AuthService.loggedIn() ? (
                       // If the user is logged in, display the user's cart total amount, and cart products and their quantities
                       <div
                         style={{

--- a/client/src/pages/Confirmation.js
+++ b/client/src/pages/Confirmation.js
@@ -70,9 +70,15 @@ const Confirmation = () => {
 
   return (
     <Card>
-      <Title level={3} style={{ marginBottom: "24px" }}>
-        Order Confirmation
-      </Title>
+      {order.status === "canceled" ? (
+        <Title level={3} style={{ marginBottom: "24px", color: "red" }}>
+          Order Canceled
+        </Title>
+      ) : (
+        <Title level={3} style={{ marginBottom: "24px" }}>
+          Order Confirmed
+        </Title>
+      )}
       <Divider />
       <Row gutter={[16, 24]}>
         {/* Display Order ID */}

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -179,6 +179,19 @@ export const CREATE_ORDER = gql`
   }
 `;
 
+export const UPDATE_ORDER = gql`
+  mutation UpdateOrder($orderId: ID!, $newStatus: String!) {
+    updateOrder(orderId: $orderId, newStatus: $newStatus) {
+      _id
+      status
+      totalAmount
+      user {
+        _id
+      }
+    }
+  }
+`;
+
 // Mutation for creating a new product review
 export const CREATE_REVIEW = gql`
   mutation CreateReview($productId: ID!, $rating: Float!, $comment: String!) {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -194,7 +194,8 @@ const typeDefs = gql`
       address: OrderAddressInput!
       status: String!
     ): Order
-    updateOrder(
+    updateOrder(orderId: ID!, newStatus: String!): Order
+    devUpdatedOrder(
       id: ID!
       name: String
       email: String


### PR DESCRIPTION
- Previously, it was possible for an order to be created even if there was an error with the payment using stripe 
- To fix this, I placed both the order creation and payment processes in separate promises and waited until both promises are resolved before displaying a success message to the user
- However, the order still gets created if its own promise is resolved, and the order creation removes from the purchased products stock quantity
- To fix this I created a new mutation that cancels the order and places the purchased items back in the stock if the order creation promise was resolved but the payment promise was rejected