### PR TITLE
Fixed pagination issue and added user-friendly displays

### DIFF
--- a/client/src/components/HomeFilters/index.js
+++ b/client/src/components/HomeFilters/index.js
@@ -21,6 +21,8 @@ const FilterOptions = ({
   setMaxRating,
   handleSortMenuClick,
   handleResetAll,
+  handlePaginationChange,
+  pageSize,
 }) => {
   // Check if any filter options are selected
   const isFilterSelected =
@@ -55,7 +57,10 @@ const FilterOptions = ({
         <Menu.Item key={category._id}>
           <Checkbox
             checked={selectedCategories.includes(category._id)}
-            onChange={() => handleCategoryMenuClick(category)}
+            onChange={() => {
+              handleCategoryMenuClick(category);
+              handlePaginationChange(1, pageSize);
+            }}
           >
             {category.name}
           </Checkbox>
@@ -72,7 +77,10 @@ const FilterOptions = ({
           <InputNumber
             min={0}
             value={minPrice}
-            onChange={(value) => setMinPrice(value !== "" ? value : undefined)}
+            onChange={(value) => {
+              setMinPrice(value !== "" ? value : undefined);
+              handlePaginationChange(1, pageSize);
+            }}
             style={{ marginLeft: 8 }}
           />
         </div>
@@ -81,7 +89,10 @@ const FilterOptions = ({
           <InputNumber
             min={0}
             value={maxPrice}
-            onChange={(value) => setMaxPrice(value !== "" ? value : undefined)}
+            onChange={(value) => {
+              setMaxPrice(value !== "" ? value : undefined);
+              handlePaginationChange(1, pageSize);
+            }}
             style={{ marginLeft: 8 }}
           />
         </div>
@@ -100,7 +111,10 @@ const FilterOptions = ({
           <InputNumber
             min={0}
             value={minRating}
-            onChange={(value) => setMinRating(value !== "" ? value : undefined)}
+            onChange={(value) => {
+              setMinRating(value !== "" ? value : undefined);
+              handlePaginationChange(1, pageSize);
+            }}
             style={{ marginLeft: 8 }}
           />
         </div>
@@ -109,7 +123,10 @@ const FilterOptions = ({
           <InputNumber
             min={0}
             value={maxRating}
-            onChange={(value) => setMaxRating(value !== "" ? value : undefined)}
+            onChange={(value) => {
+              setMaxRating(value !== "" ? value : undefined);
+              handlePaginationChange(1, pageSize);
+            }}
             style={{ marginLeft: 8 }}
           />
         </div>

--- a/client/src/components/UserForm/index.js
+++ b/client/src/components/UserForm/index.js
@@ -95,7 +95,16 @@ const UserForm = () => {
               name="password"
               rules={[
                 { required: true, message: "Please enter your password" },
+                {
+                  min: 8,
+                  message: "Password must be at least 8 characters long",
+                },
+                {
+                  pattern: /[~`!@#$%^&*()-_+=,.?'":{}|<>]/,
+                  message: "Password must contain a special character",
+                },
               ]}
+              extra="Password must be at least 8 characters long and contain a special character"
             >
               <Input.Password placeholder="Password" />
             </Form.Item>
@@ -104,7 +113,7 @@ const UserForm = () => {
                 type="primary"
                 htmlType="submit"
                 loading={signupLoading}
-                style={{ width: "100%" }}
+                style={{ width: "100%",marginTop:"5px" }}
               >
                 Sign Up
               </Button>

--- a/client/src/components/productReviews/index.js
+++ b/client/src/components/productReviews/index.js
@@ -130,6 +130,7 @@ const ProductReviews = ({ productId, refetchProduct }) => {
       });
       form.resetFields();
       message.success("Review submitted successfully");
+
       // Refetch the data to ensure the page includes the new review data without refreshing the page
       await refetchUserReview();
       await refetchProduct();
@@ -143,7 +144,7 @@ const ProductReviews = ({ productId, refetchProduct }) => {
         console.error("Error posting review:", error);
         message.error("Failed to submit review");
       }
-    } 
+    }
   };
 
   const handleUpdateReview = async (values) => {
@@ -231,7 +232,14 @@ const ProductReviews = ({ productId, refetchProduct }) => {
                 <div>
                   {editMode ? (
                     // Edit mode is enabled (the user is attempting to update their review)
-                    <Form layout="vertical" onFinish={handleUpdateReview}>
+                    <Form
+                      layout="vertical"
+                      initialValues={{
+                        rating: userReview?.rating || 0,
+                        comment: userReview?.comment || "",
+                      }}
+                      onFinish={handleUpdateReview}
+                    >
                       <Form.Item
                         name="rating"
                         label="Rating"

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -100,7 +100,7 @@ const Home = () => {
   });
 
   // Lazy Query for fetching the currently logged in user
-  const [fetchCurrentUser, {refetch: refetchUser}] = useLazyQuery(GET_ME);
+  const [fetchCurrentUser, { refetch: refetchUser }] = useLazyQuery(GET_ME);
 
   // mutation to create a shopping cart
   const [createCart] = useMutation(CREATE_CART);
@@ -229,20 +229,24 @@ const Home = () => {
   // Sets the users selected sorting option
   const handleSortMenuClick = (item) => {
     setSortOption(item.key);
+    handlePaginationChange(1, pageSize);
   };
 
   // Resets the users selected filtering options
   const handleCategoryReset = () => {
     setSelectedCategories([]);
     setCategoryNames([]);
+    handlePaginationChange(1, pageSize);
   };
   const handlePriceReset = () => {
     setMinPrice(undefined);
     setMaxPrice(undefined);
+    handlePaginationChange(1, pageSize);
   };
   const handleRatingReset = () => {
     setMinRating(undefined);
     setMaxRating(undefined);
+    handlePaginationChange(1, pageSize);
   };
   const handleResetAll = () => {
     setSelectedCategories([]);
@@ -251,6 +255,7 @@ const Home = () => {
     setMaxPrice(undefined);
     setMinRating(undefined);
     setMaxRating(undefined);
+    handlePaginationChange(1, pageSize);
   };
 
   // Array containing the products that will be presented on the page after applying filters
@@ -313,6 +318,8 @@ const Home = () => {
           sortOption={sortOption}
           handleSortMenuClick={handleSortMenuClick}
           handleResetAll={handleResetAll}
+          handlePaginationChange={handlePaginationChange}
+          pageSize={pageSize}
         />
       </div>
 


### PR DESCRIPTION
Pagination issue:
- previously if a user was on the 5th pagination page and then applied a filter, it would keep the user on the 5th pagination page, however, if there is not 5th pagination page, then nothing shows up (not even the pagination bar)
    - To fix this, I have it now that when a filter is applied, the user is reverted back to the first pagination page

User-Friendly displays:
- added a note letting the user know of the password requirements while signing up instead of having them submit their password and then get an error message
- When a user attempts to resubmit their product review, the resubmit form now has their initial reviews information, in case they only want to make a minor change, so they don't have to re-write the comment