### PR TITLE
Implemented Zustand store for the product filter states, enabling users to navigate between pages and return to the homepage while preserving their selected filters

### DIFF
--- a/client/src/components/HomeFilters/index.js
+++ b/client/src/components/HomeFilters/index.js
@@ -3,27 +3,38 @@ import { Menu, Checkbox, InputNumber, Button, Dropdown, Row, Col } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import "./index.css";
 
+import {
+  useProductCategoriesStore,
+  useProductSortingStore,
+  useProductPriceStore,
+  useProductRatingStore,
+} from "../../store/productStore";
+
 const FilterOptions = ({
   categories,
-  selectedCategories,
-  handleCategoryMenuClick,
-  handleCategoryReset,
-  minPrice,
-  maxPrice,
-  handlePriceReset,
-  setMinPrice,
-  setMaxPrice,
-  minRating,
-  maxRating,
-  sortOption,
-  handleRatingReset,
-  setMinRating,
-  setMaxRating,
-  handleSortMenuClick,
-  handleResetAll,
   handlePaginationChange,
   pageSize,
+  setCategoryNames,
 }) => {
+  // State variables for the visibility of filter options
+  const [categoryMenuVisible, setCategoryMenuVisible] = useState(false); // Controls category dropdown element visibility
+  const [priceMenuVisible, setPriceMenuVisible] = useState(false); // Controls price dropdown element visibility
+  const [ratingMenuVisible, setRatingMenuVisible] = useState(false); // Controls rating dropdown element visibility
+
+  // ---------- Store state variables for selected filter options ----------
+
+  // Get selected categories state and actions from the store
+  const { selectedCategories, setSelectedCategories, clearSelectedCategories } =
+    useProductCategoriesStore();
+  // Get the selected sort option state and action to set the state from the store
+  const { sortOption, setSortOption } = useProductSortingStore();
+  // Get the selected price filters state and actions to set the states from the store
+  const { minPrice, maxPrice, setMinPrice, setMaxPrice } =
+    useProductPriceStore();
+  // Get the selected rating filters state and actions to set the states from the store
+  const { minRating, maxRating, setMinRating, setMaxRating } =
+    useProductRatingStore();
+
   // Check if any filter options are selected
   const isFilterSelected =
     selectedCategories.length > 0 ||
@@ -31,10 +42,6 @@ const FilterOptions = ({
     maxPrice !== undefined ||
     minRating !== undefined ||
     maxRating !== undefined;
-
-  const [categoryMenuVisible, setCategoryMenuVisible] = useState(false); // Controls category dropdown element visibility
-  const [priceMenuVisible, setPriceMenuVisible] = useState(false); // Controls price dropdown element visibility
-  const [ratingMenuVisible, setRatingMenuVisible] = useState(false); // Controls rating dropdown element visibility
 
   // Toggles the visibility of the dropdown menus since these event handlers are triggered by the onVisibleChange event
   const handleCategoryMenuVisibleChange = (visible) => {
@@ -45,6 +52,46 @@ const FilterOptions = ({
   };
   const handleRatingMenuVisibleChange = (visible) => {
     setRatingMenuVisible(visible);
+  };
+
+  // ---------- Event handlers for filter options ----------
+
+  // Toggles the users selection of categories in the dropdown
+  const handleCategoryMenuClick = (item) => {
+    const itemId = item._id;
+    setSelectedCategories(itemId);
+  };
+
+  // Sets the users selected sorting option
+  const handleSortMenuClick = (item) => {
+    setSortOption(item.key);
+    handlePaginationChange(1, pageSize);
+  };
+
+  // Resets the users selected filtering options
+  const handleCategoryReset = () => {
+    clearSelectedCategories();
+    setCategoryNames([]);
+    handlePaginationChange(1, pageSize);
+  };
+  const handlePriceReset = () => {
+    setMinPrice(undefined);
+    setMaxPrice(undefined);
+    handlePaginationChange(1, pageSize);
+  };
+  const handleRatingReset = () => {
+    setMinRating(undefined);
+    setMaxRating(undefined);
+    handlePaginationChange(1, pageSize);
+  };
+  const handleResetAll = () => {
+    clearSelectedCategories();
+    setCategoryNames([]);
+    setMinPrice(undefined);
+    setMaxPrice(undefined);
+    setMinRating(undefined);
+    setMaxRating(undefined);
+    handlePaginationChange(1, pageSize);
   };
 
   // ---------- Dropdown menus for filter options ----------

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -30,18 +30,22 @@ import UserForm from "../components/UserForm";
 import FilterOptions from "../components/HomeFilters";
 import { useSignUpAndLoginStore } from "../store/userStore";
 import { useCartCreatedStore } from "../store/cartStore";
+import {
+  useProductCategoriesStore,
+  useProductSortingStore,
+  useProductPriceStore,
+  useProductRatingStore,
+} from "../store/productStore";
 
 const { Title } = Typography;
 
 const Home = () => {
   // State variables for selected filter options
-  const [selectedCategories, setSelectedCategories] = useState([]); // Stores selected category IDs
+  const { selectedCategories } = useProductCategoriesStore(); // Stores selected category ID's
   const [categoryNames, setCategoryNames] = useState(new Set()); // Stores selected category names
-  const [minPrice, setMinPrice] = useState(undefined); // Stores minimum price value
-  const [maxPrice, setMaxPrice] = useState(undefined); // Stores maximum price value
-  const [minRating, setMinRating] = useState(undefined); // Stores minimum rating value
-  const [maxRating, setMaxRating] = useState(undefined); // Stores maximum rating value
-  const [sortOption, setSortOption] = useState(undefined); // Stores selected sort option
+  const { sortOption } = useProductSortingStore(); // Stores selected product sorting option
+  const { minPrice, maxPrice } = useProductPriceStore(); // Stores selected product price filters
+  const { minRating, maxRating } = useProductRatingStore(); // Stores selected product rating filters
   const [page, setPage] = useState(1); // Current page number
   const [pageSize, setPageSize] = useState(12); // Number of products per page
 
@@ -212,52 +216,6 @@ const Home = () => {
     setPageSize(newPageSize);
   };
 
-  // ---------- Event handlers for filter options ----------
-
-  // Toggles the users selection of categories in the dropdown
-  const handleCategoryMenuClick = (item) => {
-    const itemId = item._id;
-    setSelectedCategories((prevSelectedCategories) => {
-      if (prevSelectedCategories.includes(itemId)) {
-        return prevSelectedCategories.filter((id) => id !== itemId); // Remove selected category
-      } else {
-        return [...prevSelectedCategories, itemId]; // Add selected category
-      }
-    });
-  };
-
-  // Sets the users selected sorting option
-  const handleSortMenuClick = (item) => {
-    setSortOption(item.key);
-    handlePaginationChange(1, pageSize);
-  };
-
-  // Resets the users selected filtering options
-  const handleCategoryReset = () => {
-    setSelectedCategories([]);
-    setCategoryNames([]);
-    handlePaginationChange(1, pageSize);
-  };
-  const handlePriceReset = () => {
-    setMinPrice(undefined);
-    setMaxPrice(undefined);
-    handlePaginationChange(1, pageSize);
-  };
-  const handleRatingReset = () => {
-    setMinRating(undefined);
-    setMaxRating(undefined);
-    handlePaginationChange(1, pageSize);
-  };
-  const handleResetAll = () => {
-    setSelectedCategories([]);
-    setCategoryNames([]);
-    setMinPrice(undefined);
-    setMaxPrice(undefined);
-    setMinRating(undefined);
-    setMaxRating(undefined);
-    handlePaginationChange(1, pageSize);
-  };
-
   // Array containing the products that will be presented on the page after applying filters
   const displayedProducts = filteredProdData?.filteredProducts?.products || [];
   const totalProducts = filteredProdData?.filteredProducts?.totalProducts || 0;
@@ -302,22 +260,7 @@ const Home = () => {
       <div style={{ marginBottom: "16px", textAlign: "center" }}>
         <FilterOptions
           categories={categories}
-          selectedCategories={selectedCategories}
-          handleCategoryMenuClick={handleCategoryMenuClick}
-          handleCategoryReset={handleCategoryReset}
-          minPrice={minPrice}
-          maxPrice={maxPrice}
-          handlePriceReset={handlePriceReset}
-          setMinPrice={setMinPrice}
-          setMaxPrice={setMaxPrice}
-          minRating={minRating}
-          maxRating={maxRating}
-          handleRatingReset={handleRatingReset}
-          setMinRating={setMinRating}
-          setMaxRating={setMaxRating}
-          sortOption={sortOption}
-          handleSortMenuClick={handleSortMenuClick}
-          handleResetAll={handleResetAll}
+          setCategoryNames={setCategoryNames}
           handlePaginationChange={handlePaginationChange}
           pageSize={pageSize}
         />

--- a/client/src/store/productStore.js
+++ b/client/src/store/productStore.js
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+
+// Store for managing selected categories
+const useProductCategoriesStore = create((set) => ({
+  selectedCategories: [],
+
+  // Action to set selected categories
+  setSelectedCategories: (itemId) => {
+    set((state) => {
+      const { selectedCategories } = state;
+      if (selectedCategories.includes(itemId)) {
+        // If category is already selected, remove it from the array
+        return {
+          selectedCategories: selectedCategories.filter((id) => id !== itemId),
+        };
+      } else {
+        // If category is not selected, add it to the array
+        return { selectedCategories: [...selectedCategories, itemId] };
+      }
+    });
+  },
+
+  // Action to clear selected categories
+  clearSelectedCategories: () => {
+    set({ selectedCategories: [] });
+  },
+}));
+
+// Store for managing the sort option
+const useProductSortingStore = create((set) => ({
+  sortOption: undefined,
+
+  // Action to set the sort option
+  setSortOption: (value) => set(() => ({ sortOption: value })),
+}));
+
+// Store for managing the minimum and maximum price filters
+const useProductPriceStore = create((set) => ({
+  minPrice: undefined,
+
+  // Action to set the minimum price
+  setMinPrice: (value) => set(() => ({ minPrice: value })),
+
+  maxPrice: undefined,
+
+  // Action to set the maximum price
+  setMaxPrice: (value) => set(() => ({ maxPrice: value })),
+}));
+
+// Store for managing the minimum and maximum rating filters
+const useProductRatingStore = create((set) => ({
+  minRating: undefined,
+
+  // Action to set the minimum rating
+  setMinRating: (value) => set(() => ({ minRating: value })),
+
+  maxRating: undefined,
+
+  // Action to set the maximum rating
+  setMaxRating: (value) => set(() => ({ maxRating: value })),
+}));
+
+export {
+  useProductCategoriesStore,
+  useProductSortingStore,
+  useProductPriceStore,
+  useProductRatingStore,
+};


### PR DESCRIPTION
Previously, when the user applied filters on the homepage and then clicked on a product to navigate to the single product page, their selected filter options would be lost upon returning to the homepage. This was because the states would reset to their default values. To address this issue, I implemented a Zustand store to store the selected filter options, and then imported it into the homepage file. Now, when the user returns to the homepage, their filter options are retained, providing a consistent filtering experience.